### PR TITLE
Update prekubeadm scripts urls

### DIFF
--- a/specs/capz-control-plane.yaml
+++ b/specs/capz-control-plane.yaml
@@ -72,7 +72,7 @@ spec:
           cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     preKubeadmCommands:
-    - curl -Lo /tmp/kubeadm-bootstrap.sh https://raw.githubusercontent.com/ionutbalutoiu/cloudbase-init-capz-demo/update-guide/scripts/kubeadm-bootstrap.sh
+    - curl -Lo /tmp/kubeadm-bootstrap.sh https://raw.githubusercontent.com/adelina-t/cloudbase-init-capz-demo/master/scripts/kubeadm-bootstrap.sh
     - bash /tmp/kubeadm-bootstrap.sh
     useExperimentalRetryJoin: true
 ---

--- a/specs/capz-windows-workers.yaml
+++ b/specs/capz-windows-workers.yaml
@@ -86,5 +86,5 @@ spec:
             cloud-provider: azure
           name: '{{ v1.local_hostname }}'
       preKubeadmCommands:
-      - curl.exe -Lo /tmp/kubeadm-bootstrap.ps1 https://raw.githubusercontent.com/ionutbalutoiu/cloudbase-init-capz-demo/update-guide/scripts/kubeadm-bootstrap.ps1
+      - curl.exe -Lo /tmp/kubeadm-bootstrap.ps1 https://raw.githubusercontent.com/adelina-t/cloudbase-init-capz-demo/master/scripts/kubeadm-bootstrap.ps1
       - powershell -C "/tmp/kubeadm-bootstrap.ps1"


### PR DESCRIPTION
Make sure it points to the original repository.

Now that PR https://github.com/adelina-t/cloudbase-init-capz-demo/pull/1 got merged, we can update the URLs as well.